### PR TITLE
Update README.md to use v1 instead of v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
     - uses: Azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }} 
-    - uses: Azure/get-keyvault-secrets@v1.0
+    - uses: Azure/get-keyvault-secrets@v1
       with:
         keyvault: "my
         Vault"
@@ -87,7 +87,7 @@ jobs:
     - uses: Azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }} # Define secret variable in repository settings as per action documentation
-    - uses: Azure/get-keyvault-secrets@v1.0
+    - uses: Azure/get-keyvault-secrets@v1
       with:
         keyvault: "myKeyVault"
         secrets: 'mySecret1, mySecret2'


### PR DESCRIPTION
Changing to "uses v1" just to not confuse those who are just starting to work.

v1.0 is not working for now. Reason : still reference set-env, but the `set-env` command is disabled.
The use of v1.0 generate the next error : "Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/", but v1 works correctly