### PR TITLE
Updated sample examples to use v1 tag instead of being pinned to an old version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
     - uses: Azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }} 
-    - uses: Azure/get-keyvault-secrets@v1.0
+    - uses: Azure/get-keyvault-secrets@v1
       with:
         keyvault: "my
         Vault"
@@ -87,7 +87,7 @@ jobs:
     - uses: Azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }} # Define secret variable in repository settings as per action documentation
-    - uses: Azure/get-keyvault-secrets@v1.0
+    - uses: Azure/get-keyvault-secrets@v1
       with:
         keyvault: "myKeyVault"
         secrets: 'mySecret1, mySecret2'


### PR DESCRIPTION
Copy & pasting this sample will not work since it's an old version that doesn't run anymore due to the use of `set-variable` command.

Pinning it go v1 instead will make the sample work and precent such events in the future.